### PR TITLE
Fixed a problem with "0" as a key for the last entry of an array definition

### DIFF
--- a/src/IniParser.php
+++ b/src/IniParser.php
@@ -151,7 +151,7 @@ class IniParser {
                 $path = explode('.', $k);
 
                 $current =& $output;
-                while (($current_key = array_shift($path))) {
+                while (($current_key = array_shift($path)) !== null) {
                     if ('string' === gettype($current)) {
                         $current = array($current);
                     }

--- a/tests/Test/IniParserTest.php
+++ b/tests/Test/IniParserTest.php
@@ -246,6 +246,22 @@ class IniParserTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests that arrays with 0 as key work as expected
+     *
+     * @return void
+     */
+    public function testArrayWithZeroAsKey()
+    {
+        $configObj = $this->getConfig('fixture09.ini');
+        $config    = $this->phpUnitDoesntUnderstandArrayObject($configObj);
+
+        $this->assertObjectHasAttribute('helloworld', $configObj);
+        $this->assertObjectHasAttribute('hello', $configObj->helloworld);
+
+        $this->assertEquals((array)$configObj->helloworld->hello, array(1 => 'world', 0 => 'hello'));
+    }
+
+    /**
      * Create a config array (from the given fixture).
      *
      * @param $file

--- a/tests/fixtures/fixture09.ini
+++ b/tests/fixtures/fixture09.ini
@@ -1,0 +1,3 @@
+[helloworld]
+hello.1 = world
+hello.0 = hello


### PR DESCRIPTION
E.g. the following ini file resulted in unexpected results without the provided patch:

```
[helloworld]
hello.1 = world
hello.0 = hello
```

In case the key is "0" the while condition was also false even though it was expected to be true.

```
while (($current_key = array_shift($path)) !== null) {
```

I have added the correct check comparing to null in order to make sure that keys with "0" will be handled correctly. I have further added a test to cover this specific case.
