### PR TITLE
Allow nested array appending to work. i.e. nesting.a[] = 1

### DIFF
--- a/src/IniParser.php
+++ b/src/IniParser.php
@@ -174,7 +174,7 @@ class IniParser {
         $output = $this->getArrayValue();
         $append_regex = '/\s*\+\s*$/';
         foreach ($arr as $k => $v) {
-            if (is_array($v)) {
+            if (is_array($v) && FALSE === strpos($k, '.')) {
                 // this element represents a section; recursively parse the value
                 $output[$k] = $this->parseKeys($v);
             } else {
@@ -205,7 +205,10 @@ class IniParser {
                 }
 
                 // parse value
-                $value = $this->parseValue($v);
+                $value = $v;
+                if (!is_array($v)) {
+                  $value = $this->parseValue($v);
+                }
 
                 if ($append && $current !== null) {
                     if (is_array($value)) {

--- a/tests/Test/IniParserTest.php
+++ b/tests/Test/IniParserTest.php
@@ -346,6 +346,23 @@ class IniParserTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests that appending to a potentially non-existent array works as expected
+     * when also using property nesting.
+     *
+     * @return void
+     */
+    public function testNestedArrayAppend()
+    {
+        $configObj = $this->getConfig('fixture11.ini');
+        $config    = $this->phpUnitDoesntUnderstandArrayObject($configObj);
+        $expected = array(1, 2, 'c');
+
+        $this->assertArrayHasKey('nesting', $config);
+        $this->assertArrayHasKey('a', $config['nesting']);
+        $this->assertEquals($expected, $config['nesting']['a']);
+    }
+
+    /**
      * Create a config array (from the given fixture).
      *
      * @param $file

--- a/tests/fixtures/fixture11.ini
+++ b/tests/fixtures/fixture11.ini
@@ -1,0 +1,3 @@
+nesting.a[] = 1
+nesting.a[] = 2
+nesting.a[] = "c"


### PR DESCRIPTION
This is in response to https://github.com/austinhyde/IniParser/pull/17. Pulled down updates, and added changes for nested array appending.
