### PR TITLE
Add support for parametric values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "austinhyde/iniparser",
+    "name": "tajawal/php-ini-parser",
     "description": "A Zend_Config_Ini like parser for .ini files.",
     "type": "library",
     "license": "MIT",

--- a/src/IniParser.php
+++ b/src/IniParser.php
@@ -35,6 +35,12 @@ class IniParser {
     public $parametric_parsing = false;
 
     /**
+     * Separator in case of multiple values
+     * @var string
+     */
+    public $multiValueSeparator = '|';
+
+    /**
      * Use ArrayObject to allow array work as object (true) or use native arrays (false)
      * @var boolean
      */
@@ -255,7 +261,7 @@ class IniParser {
         $parsedValue =array();
         foreach ($parameters as $parameter) {
             list($parameterKey, $parameterValue) = explode('=', $parameter);
-            $parsedValue[$parameterKey] = strpos($parameterValue, '|') !== false ? explode('|', $parameterValue) : $parameterValue;
+            $parsedValue[$parameterKey] = strpos($parameterValue, $this->multiValueSeparator) !== false ? explode($this->multiValueSeparator, $parameterValue) : $parameterValue;
         }
 
         return $parsedValue;

--- a/src/IniParser.php
+++ b/src/IniParser.php
@@ -223,7 +223,7 @@ class IniParser {
                             throw new LogicException("Cannot append array to inherited value '{$k}'");
                         }
                         $value = array_merge($current, $value);
-                        $value = array_map([$this, 'parseParametricValue'], $value);
+                        $value = array_map(array($this, 'parseParametricValue'), $value);
                     } else {
                         $value = $current . $value;
                     }
@@ -249,10 +249,10 @@ class IniParser {
             return $value;
         }
 
-        // As there could be multiple parameters. Each separated by single space
+        // As there could be multiple parameters separated by spaces
         $parameters = preg_split('/\s+/', $value);
 
-        $parsedValue =[];
+        $parsedValue =array();
         foreach ($parameters as $parameter) {
             list($parameterKey, $parameterValue) = explode('=', $parameter);
             $parsedValue[$parameterKey] = strpos($parameterValue, '|') !== false ? explode('|', $parameterValue) : $parameterValue;

--- a/src/IniParser.php
+++ b/src/IniParser.php
@@ -255,7 +255,7 @@ class IniParser {
         $parsedValue =[];
         foreach ($parameters as $parameter) {
             list($parameterKey, $parameterValue) = explode('=', $parameter);
-            $parsedValue[$parameterKey] = $parameterValue;
+            $parsedValue[$parameterKey] = strpos($parameterValue, '|') !== false ? explode('|', $parameterValue) : $parameterValue;
         }
 
         return $parsedValue;

--- a/src/IniParser.php
+++ b/src/IniParser.php
@@ -250,7 +250,7 @@ class IniParser {
         }
 
         // As there could be multiple parameters. Each separated by single space
-        $parameters = explode(' ', $value);
+        $parameters = preg_split('/\s+/', $value);
 
         $parsedValue =[];
         foreach ($parameters as $parameter) {

--- a/src/IniParser.php
+++ b/src/IniParser.php
@@ -69,6 +69,13 @@ class IniParser {
     const PARSE_JSON = 2;
 
     /**
+     * Normal: 0
+     * Raw: 1
+     * Typed: 2
+     */
+    const INI_PARSE_OPTION = 0;
+
+    /**
      * Array literals parse mode
      * @var int
      */
@@ -99,7 +106,7 @@ class IniParser {
             throw new LogicException("Need a file to parse.");
         }
 
-        $simple_parsed = parse_ini_file($this->file, true);
+        $simple_parsed = parse_ini_file($this->file, true, static::INI_PARSE_OPTION);
         $inheritance_parsed = $this->parseSections($simple_parsed);
 
         return $this->parseKeys($inheritance_parsed);
@@ -113,7 +120,7 @@ class IniParser {
      * @return array
      */
     public function process($src) {
-        $simple_parsed = parse_ini_string($src, true);
+        $simple_parsed = parse_ini_string($src, true, static::INI_PARSE_OPTION);
         $inheritance_parsed = $this->parseSections($simple_parsed);
         return $this->parseKeys($inheritance_parsed);
     }

--- a/tests/Test/IniParserTest.php
+++ b/tests/Test/IniParserTest.php
@@ -218,25 +218,25 @@ class IniParserTest extends PHPUnit_Framework_TestCase
      */
     public function testParametricValues()
     {
-        $configObj = $this->getConfig('fixture12.ini', [
+        $configObj = $this->getConfig('fixture12.ini', array(
             'parametric_parsing' => true
-        ]);
+        ));
         $config    = $this->phpUnitDoesntUnderstandArrayObject($configObj);
 
         $expected = array(
-            'guest' => [
-                'user_auth_login' => [
+            'guest' => array(
+                'user_auth_login' => array(
                     'allowed' => 1,
-                    'app' => [
+                    'app' => array(
                         'FLIGHT_API',
                         'HOTEL_API'
-                    ],
+                    ),
                     'verb' => '*'
-                ],
-                'user_account_register' => [
+                ),
+                'user_account_register' => array(
                     'allowed' => 1
-                ]
-            ]
+                )
+            )
         );
 
         $this->assertEquals($expected, $config);
@@ -246,7 +246,7 @@ class IniParserTest extends PHPUnit_Framework_TestCase
      * Tests that appending to a potentially non-existent array works as expected
      * Spawned by https://github.com/austinhyde/IniParser/issues/6
      * and https://github.com/austinhyde/IniParser/pull/7
-     * 
+     *
      * @return void
      */
     public function testArrayAppend()

--- a/tests/Test/IniParserTest.php
+++ b/tests/Test/IniParserTest.php
@@ -212,6 +212,37 @@ class IniParserTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests the parametric values i.e. parameter has more parameters against it
+     *
+     * @return void
+     */
+    public function testParametricValues()
+    {
+        $configObj = $this->getConfig('fixture12.ini', [
+            'parametric_parsing' => true
+        ]);
+        $config    = $this->phpUnitDoesntUnderstandArrayObject($configObj);
+
+        $expected = array(
+            'guest' => [
+                'user_auth_login' => [
+                    'allowed' => 1,
+                    'app' => [
+                        'FLIGHT_API',
+                        'HOTEL_API'
+                    ],
+                    'verb' => '*'
+                ],
+                'user_account_register' => [
+                    'allowed' => 1
+                ]
+            ]
+        );
+
+        $this->assertEquals($expected, $config);
+    }
+
+    /**
      * Tests that appending to a potentially non-existent array works as expected
      * Spawned by https://github.com/austinhyde/IniParser/issues/6
      * and https://github.com/austinhyde/IniParser/pull/7

--- a/tests/fixtures/fixture12.ini
+++ b/tests/fixtures/fixture12.ini
@@ -1,0 +1,3 @@
+[guest]
+user_auth_login = "allowed=1 app=FLIGHT_API|HOTEL_API verb=*"
+user_account_register = "allowed=1"


### PR DESCRIPTION
Sometimes it may be required to add more detail with a certain value. 

In current implementation you could do this by providing the value in the form of JSON but in case of large number of associated values, it could easily get messy.

This PR enhances the parser to add support for parametric strings.
## Example

I can have my ini file like below

``` ini
[guest]
user_auth_login = "allowed=1 apps=FLIGHT_API|HOTEL_API verb=*"
user_account_register = "allowed=1 verb=POST"
user_account_add = "allowed=0 verb=POST"
```

and this will be turned to

``` json
{
   "guest":{
      "user_auth_login":{
         "allowed":"1",
         "app":[
            "FLIGHT_API",
            "HOTEL_API"
         ],
         "verb":"*"
      },
      "user_account_register":{
         "allowed":"1"
      }
   }
}
```
## How to Use

``` php
$parser = new IniParser('tests/fixtures/fixture12.ini');
// Setting this will parse the parameters wherever required
$parser->parametric_parsing = true;
$parsed = $parser->parse();
```

PS, relevant tests have been added
